### PR TITLE
Refactor '.after' method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ ported to `java` as interface with set of default methods which simplify typical
 public interface Enumerable<X> extends Collection<X> {
     /**
      * Passes each element of the collection to the given block.
+     * If no predicate (null) is given, then true is returned instead.
      * @param prd The predicate to match each element.
      * @return The true if the block never returns false or nil.
      */
@@ -68,6 +69,7 @@ public interface Enumerable<X> extends Collection<X> {
 
     /**
      * Passes at least one element of the collection to the given block.
+     * If no predicate (null) is given, then true is returned instead.
      * @param prd The predicate to match at least one element.
      * @return The true if the block never returns false or nil.
      */
@@ -77,6 +79,7 @@ public interface Enumerable<X> extends Collection<X> {
 
     /**
      * Doesn't passes elements of the collection to the given block.
+     * If no predicate (null) is given, then true is returned instead.
      * @param prd The predicate to match none elements.
      * @return The true if the block never returns false or nil.
      */
@@ -155,7 +158,6 @@ public interface Enumerable<X> extends Collection<X> {
      * Returns a result of the reduction of the elements in this stream,
      * using provided identity value and accumulation function operator.
      * If no function (null) is given, then identity is returned instead.
-     *
      * @param idn The identity value of the accumulation function.
      * @param opr The accumulation function operator which combining previous and current values.
      * @return Result of of combining elements.
@@ -167,7 +169,7 @@ public interface Enumerable<X> extends Collection<X> {
     /**
      * Returns an enumerable containing all elements of enumerable
      *  after the first one which corresponds the condition.
-     * If no predicate (null) is given, then 'this' is returned instead.
+     * If no predicate (null) is given, then empty enumerable is returned instead.
      * @param prd The function to match element after which enumerable elements should be returned.
      * @return The enumerable.
      */
@@ -178,10 +180,11 @@ public interface Enumerable<X> extends Collection<X> {
     /**
      * Returns an enumerable containing a certain number of elements of enumerable
      *  after the first one which corresponds the condition.
-     * If no predicate (null) is given, then 'this' of the specified size is returned instead.
+     * If no predicate (null) is given, then empty enumerable is returned instead.
      * @param prd The function to match element after which enumerable elements should be returned.
      * @param size The number of elements the enumerable should be limited to.
      * @return The enumerable.
+     * @throws IllegalArgumentException If the size is negative.
      */
     default Enumerable<X> after(Predicate<X> prd, long size) {
         // ...
@@ -189,7 +192,7 @@ public interface Enumerable<X> extends Collection<X> {
 
     /**
      * Returns the next element of enumerable after the first one which corresponds the condition.
-     * If no predicate (null) is given, or no element found then alternative is returned instead.
+     * If no predicate (null) is given, or no element found then null is returned instead.
      * @param prd The function to match element after which enumerable element should be returned.
      * @return The next element of enumerable after the first one which corresponds the condition.
      */

--- a/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
+++ b/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
@@ -217,7 +217,7 @@ public interface Enumerable<X> extends Collection<X> {
     /**
      * Returns an enumerable containing all elements of enumerable
      *  after the first one which corresponds the condition.
-     * If no predicate (null) is given, then 'this' is returned instead.
+     * If no predicate (null) is given, then empty enumerable is returned instead.
      * @param prd The function to match element after which enumerable elements should be returned.
      * @return The enumerable.
      */
@@ -228,7 +228,7 @@ public interface Enumerable<X> extends Collection<X> {
     /**
      * Returns an enumerable containing a certain number of elements of enumerable
      *  after the first one which corresponds the condition.
-     * If no predicate (null) is given, then 'this' of the specified size is returned instead.
+     * If no predicate (null) is given, then empty enumerable is returned instead.
      * @param prd The function to match element after which enumerable elements should be returned.
      * @param size The number of elements the enumerable should be limited to.
      * @return The enumerable.
@@ -238,10 +238,8 @@ public interface Enumerable<X> extends Collection<X> {
         final Enumerable<X> out;
         if (size < 0) {
             throw new IllegalArgumentException(Long.toString(size));
-        } else if (size == 0) {
+        } else if (size == 0 || prd == null) {
             out = new Empty<>();
-        } else if (prd == null) {
-            out = new Linked<>(this.stream().limit(size).collect(Collectors.toList()));
         } else {
             boolean found = false;
             out = new Linked<>();

--- a/src/test/java/io/github/dgroup/enumerable4j/AfterTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AfterTest.java
@@ -45,12 +45,9 @@ public final class AfterTest {
     @Test
     void nullPredicate() {
         new Assertion<>(
-            "In case null-function the self enumerable is expected",
-            new Linked<>(1, 2, 3, 4).after(null),
-            new AllOf<>(
-                new HasSize(4),
-                new HasValues<>(1, 2, 3, 4)
-            )
+            "In case of a null predicate, an empty enumeration is expected",
+            new Linked<>(1, 2, 3).after(null),
+            new IsEmptyIterable<>()
         ).affirm();
     }
 
@@ -123,19 +120,16 @@ public final class AfterTest {
     @Test
     void nullPredicateWithSize() {
         new Assertion<>(
-            "In case null-function and specified size a enumerable of the size is expected",
+            "In case of a null predicate, an empty enumeration is expected",
             new Linked<>(1, 2, 3, 4).after(null, 2),
-            new AllOf<>(
-                new HasSize(2),
-                new HasValues<>(1, 2)
-            )
+            new IsEmptyIterable<>()
         ).affirm();
     }
 
     @Test
     void nullPredicateAndZeroSize() {
         new Assertion<>(
-            "If the size value is 0, an empty collection is returned",
+            "In case of a null predicate or zero size, an empty enumeration is expected",
             new Linked<>(1, 2, 3).after(null, 0),
             new IsEmptyIterable<>()
         ).affirm();


### PR DESCRIPTION
Refactor the null predicate case:
```java
YourOwnCollection<Integer> src = ...  // with elements [1, 2, 3]
```

Current result:
```java
Enumerable<Integer> result = src.after(null); // [] - empty enumerable
```

Previous result:
```java
Enumerable<Integer> result = src.after(null); // [1, 2, 3] - the same enumerable
```

-----
[View rendered readme.md](https://github.com/dykov/enumerable4j/blob/master/readme.md)