### PR TITLE
Add vararg support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,10 +56,10 @@ ported to `java` as interface with set of default methods which simplify typical
  * ability to sort. The class must provide a method each, which yields successive members of the
  * collection.
  *
- * @param <X> The type of entities.
+ * @param <T> The type of entities.
  * @since 0.1.0
  */
-public interface Enumerable<X> extends Collection<X> {
+public interface Enumerable<T> extends Collection<T> {
     /**
      * Passes each element of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
@@ -94,10 +94,11 @@ public interface Enumerable<X> extends Collection<X> {
      * Returns an enumerable containing all elements of enumerable for which the given functions
      *  return a true value.
      * If no predicate (null) is given, then 'this' is returned instead.
-     * @param prd The array of functions to match each element.
+     * @param first The function to match each element.
+     * @param other The array of functions to match each element.
      * @return The enumerable.
      */
-    default Enumerable<T> select(Predicate<T>... prd) {
+    default Enumerable<T> select(Predicate<T> first, Predicate<T>... other) {
         // ...
     }
 
@@ -165,7 +166,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @param opr The accumulation function operator which combining previous and current values.
      * @return Result of of combining elements.
      */
-    default X reduce(X idn, BinaryOperator<X> opr) {
+    default X reduce(T idn, BinaryOperator<T> opr) {
         // ...
     }
 
@@ -176,7 +177,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @param prd The function to match element after which enumerable elements should be returned.
      * @return The enumerable.
      */
-    default Enumerable<X> after(Predicate<X> prd) {
+    default Enumerable<T> after(Predicate<T> prd) {
         // ...
     }
 
@@ -189,7 +190,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @return The enumerable.
      * @throws IllegalArgumentException If the size is negative.
      */
-    default Enumerable<X> after(Predicate<X> prd, long size) {
+    default Enumerable<T> after(Predicate<T> prd, long size) {
         // ...
     }
 
@@ -199,7 +200,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @param prd The function to match element after which enumerable element should be returned.
      * @return The next element of enumerable after the first one which corresponds the condition.
      */
-    default X next(Predicate<X> prd) {
+    default T next(Predicate<T> prd) {
         // ...
     }
 
@@ -210,7 +211,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @param alt The alternative to return in case of null predicate or no element found.
      * @return The next element of enumerable after the first one which corresponds the condition.
      */
-    default X next(Predicate<X> prd, X alt) {
+    default T next(Predicate<X> prd, T alt) {
         // ...
     }
 
@@ -221,7 +222,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @param enm The given enumerable.
      * @return The enumerable.
      */
-    default Enumerable<X> chain(Enumerable<X> enm) {
+    default Enumerable<T> chain(Enumerable<T> enm) {
         // ...
     }
 
@@ -231,7 +232,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @return The enumerable.
      * @throws IllegalArgumentException If the size is negative.
      */
-    default Enumerable<X> take(long size) {
+    default Enumerable<T> take(long size) {
         // ...
     }
 
@@ -241,7 +242,7 @@ public interface Enumerable<X> extends Collection<X> {
      * @param act An action to perform on the elements.
      * @return The enumerable.
      */
-    default Enumerable<X> each(Consumer<X> act) {
+    default Enumerable<T> each(Consumer<T> act) {
         // ...
     }
 }
@@ -292,33 +293,29 @@ See [more](./src/main/java/io/github/dgroup/enumerable4j/Enumerable.java).
 #### .all
 
 ```java
-YourOwnCollection<Integer> src = ...                       // with elements [1, 2, 3]   
-boolean allPositive = src.all(val -> val > 0);             // true 
-boolean matched = src.all(val -> val > 0, val -> val < 4); // true 
+YourOwnCollection<Integer> src = ...           // with elements [1, 2, 3]   
+boolean allPositive = src.all(val -> val > 0); // true 
 ```
 
 #### .any
 
 ```java
-YourOwnCollection<Integer> src = ...                       // with elements [-1, 0, 1]
-boolean oneIsPositive = src.any(val -> val > 0);           // true 
-boolean matched = src.any(val -> val > 0, val -> val < 2); // true 
+YourOwnCollection<Integer> src = ...             // with elements [-1, 0, 1]
+boolean oneIsPositive = src.any(val -> val > 0); // true 
 ```
 
 #### .none
 
 ```java
-YourOwnCollection<Integer> src = ...                         // with elements [-2, -1, 0]
-boolean noneIsPositive = src.none(val -> val > 0);           // true 
-boolean matched = src.none(val -> val > 0, val -> val < -3); // true 
+YourOwnCollection<Integer> src = ...               // with elements [-2, -1, 0]
+boolean noneIsPositive = src.none(val -> val > 0); // true 
 ```
 
 #### .select
 
 ```java
-YourOwnCollection<Integer> src = ...                                      // with elements [-1, 1, 2]
-Enumerable<Integer> positive = src.select(val -> val > 0);                // [1, 2] 
-Enumerable<Integer> matched = src.select(val -> val > 0, val -> val < 2); // [1] 
+YourOwnCollection<Integer> src = ...                       // with elements [-1, 1, 2]
+Enumerable<Integer> positive = src.select(val -> val > 0); // [1, 2] 
 ```
 
 #### .reject

--- a/readme.md
+++ b/readme.md
@@ -63,30 +63,33 @@ public interface Enumerable<T> extends Collection<T> {
     /**
      * Passes each element of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
-     * @param prd The array of functions to match each element.
+     * @param first The function to match each element.
+     * @param other The array of functions to match each element.
      * @return True if the functions never return false or nil.
      */
-    default boolean all(Predicate<T>... prd) {
+    default boolean all(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
     /**
      * Passes at least one element of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
-     * @param prd The array of functions to match at least one element.
+     * @param first The function to match at least one element.
+     * @param other The array of functions to match at least one element.
      * @return True if the functions never return false or nil.
      */
-    default boolean any(Predicate<T>... prd) {
+    default boolean any(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
     /**
      * Doesn't passes elements of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
-     * @param prd The array of functions to match none elements.
+     * @param first The function to match none elements.
+     * @param other The array of functions to match none elements.
      * @return True if the functions never returns false or nil.
      */
-    default boolean none(Predicate<T>... prd) {
+    default boolean none(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
@@ -98,7 +101,7 @@ public interface Enumerable<T> extends Collection<T> {
      * @param other The array of functions to match each element.
      * @return The enumerable.
      */
-    default Enumerable<T> select(Predicate<T> first, Predicate<T>... other) {
+    default Enumerable<X> select(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
@@ -106,10 +109,11 @@ public interface Enumerable<T> extends Collection<T> {
      * Returns an enumerable containing all elements of enumerable for which the given function
      *  returns a false value.
      * If no predicate (null) is given, then 'this' is returned instead.
-     * @param prd The function to match each element.
+     * @param first The function to match each element.
+     * @param other The array of functions to match each element.
      * @return The enumerable.
      */
-    default Enumerable<T> reject(Predicate<T> prd) {
+    default Enumerable<X> reject(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
@@ -151,10 +155,11 @@ public interface Enumerable<T> extends Collection<T> {
      * Returns the number of elements that are present in enumerable for which the given
      * function return true.
      * If no function (null) is given, then 'size' is returned instead.
-     * @param prd The function to match each element.
+     * @param first The function to match each element.
+     * @param other The array of functions to match each element.
      * @return Number of elements satisfying the given function.
      */
-    default long count(Predicate<T> prd) {
+    default long count(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 

--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ public interface Enumerable<T> extends Collection<T> {
      * @param opr The accumulation function operator which combining previous and current values.
      * @return Result of of combining elements.
      */
-    default X reduce(T idn, BinaryOperator<T> opr) {
+    default T reduce(T idn, BinaryOperator<T> opr) {
         // ...
     }
 
@@ -211,7 +211,7 @@ public interface Enumerable<T> extends Collection<T> {
      * @param alt The alternative to return in case of null predicate or no element found.
      * @return The next element of enumerable after the first one which corresponds the condition.
      */
-    default T next(Predicate<X> prd, T alt) {
+    default T next(Predicate<T> prd, T alt) {
         // ...
     }
 
@@ -264,7 +264,7 @@ See [more](./src/main/java/io/github/dgroup/enumerable4j/Enumerable.java).
     /**
      * The collection which you implemented in your project for some purposes.
      */
-    public class YourOwnCollection<X> extends Collection<X> implements Enumerable<X> {
+    public class YourOwnCollection<T> extends Collection<T> implements Enumerable<T> {
         //
     }
     ```

--- a/readme.md
+++ b/readme.md
@@ -70,12 +70,33 @@ public interface Enumerable<X> extends Collection<X> {
     }
 
     /**
+     * Passes each element of the collection to the each given blocks.
+     * @param first The predicate to match each element.
+     * @param other The array of predicates to match each element.
+     * @return The true if the blocks never return false or nil.
+     */
+    default boolean all(Predicate<X> first, Predicate<X>... other) {
+        // ...
+    }
+
+    /**
      * Passes at least one element of the collection to the given block.
      * If no predicate (null) is given, then true is returned instead.
      * @param prd The predicate to match at least one element.
      * @return The true if the block never returns false or nil.
      */
     default boolean any(Predicate<T> prd) {
+        // ...
+    }
+
+    /**
+     * Passes at least one element of the collection to the each given blocks.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param first The predicate to match at least one element.
+     * @param other The array of predicates to match at least one element.
+     * @return The true if the blocks never return false or nil.
+     */
+    default boolean any(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
@@ -90,6 +111,17 @@ public interface Enumerable<X> extends Collection<X> {
     }
 
     /**
+     * Doesn't passes elements of the collection to the each given blocks.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param first The predicate to match none elements.
+     * @param other The array of predicates to match none elements.
+     * @return The true if the blocks never returns false or nil.
+     */
+    default boolean none(Predicate<X> first, Predicate<X>... other) {
+        // ...
+    }
+    
+    /**
      * Returns an enumerable containing all elements of enumerable for which the given function
      *  returns a true value.
      * If no predicate (null) is given, then 'this' is returned instead.
@@ -97,6 +129,18 @@ public interface Enumerable<X> extends Collection<X> {
      * @return The enumerable.
      */
     default Enumerable<T> select(Predicate<T> prd) {
+        // ...
+    }
+
+    /**
+     * Returns an enumerable containing all elements of enumerable for which the given functions
+     *  return a true value.
+     * If no predicate (null) is given, then 'this' is returned instead.
+     * @param first The function to match each element.
+     * @param other The array of predicates to match each element.
+     * @return The enumerable.
+     */
+    default Enumerable<X> select(Predicate<X> first, Predicate<X>... other) {
         // ...
     }
 
@@ -280,29 +324,33 @@ See [more](./src/main/java/io/github/dgroup/enumerable4j/Enumerable.java).
 #### .all
 
 ```java
-YourOwnCollection<Integer> src = ...           // with elements [1, 2, 3]   
-boolean allPositive = src.all(val -> val > 0); // true 
+YourOwnCollection<Integer> src = ...                       // with elements [1, 2, 3]   
+boolean allPositive = src.all(val -> val > 0);             // true 
+boolean matched = src.all(val -> val > 0, val -> val < 4); // true 
 ```
 
 #### .any
 
 ```java
-YourOwnCollection<Integer> src = ...             // with elements [-1, 0, 1]
-boolean oneIsPositive = src.any(val -> val > 0); // true 
+YourOwnCollection<Integer> src = ...                       // with elements [-1, 0, 1]
+boolean oneIsPositive = src.any(val -> val > 0);           // true 
+boolean matched = src.any(val -> val > 0, val -> val < 2); // true 
 ```
 
 #### .none
 
 ```java
-YourOwnCollection<Integer> src = ...               // with elements [-2, -1, 0]
-boolean noneIsPositive = src.none(val -> val > 0); // true 
+YourOwnCollection<Integer> src = ...                         // with elements [-2, -1, 0]
+boolean noneIsPositive = src.none(val -> val > 0);           // true 
+boolean matched = src.none(val -> val > 0, val -> val < -3); // true 
 ```
 
 #### .select
 
 ```java
-YourOwnCollection<Integer> src = ...                       // with elements [-1, 1, 2]
-Enumerable<Integer> positive = src.select(val -> val > 0); // [1, 2] 
+YourOwnCollection<Integer> src = ...                                      // with elements [-1, 1, 2]
+Enumerable<Integer> positive = src.select(val -> val > 0);                // [1, 2] 
+Enumerable<Integer> matched = src.select(val -> val > 0, val -> val < 2); // [1] 
 ```
 
 #### .reject

--- a/readme.md
+++ b/readme.md
@@ -61,75 +61,32 @@ ported to `java` as interface with set of default methods which simplify typical
  */
 public interface Enumerable<X> extends Collection<X> {
     /**
-     * Passes each element of the collection to the given block.
+     * Passes each element of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
-     * @param prd The predicate to match each element.
-     * @return The true if the block never returns false or nil.
+     * @param prd The array of functions to match each element.
+     * @return True if the functions never return false or nil.
      */
-    default boolean all(Predicate<T> prd) {
+    default boolean all(Predicate<T>... prd) {
         // ...
     }
 
     /**
-     * Passes each element of the collection to the each given blocks.
-     * @param first The predicate to match each element.
-     * @param other The array of predicates to match each element.
-     * @return The true if the blocks never return false or nil.
+     * Passes at least one element of the collection to the each given function.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param prd The array of functions to match at least one element.
+     * @return True if the functions never return false or nil.
      */
-    default boolean all(Predicate<X> first, Predicate<X>... other) {
+    default boolean any(Predicate<T>... prd) {
         // ...
     }
 
     /**
-     * Passes at least one element of the collection to the given block.
+     * Doesn't passes elements of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
-     * @param prd The predicate to match at least one element.
-     * @return The true if the block never returns false or nil.
+     * @param prd The array of functions to match none elements.
+     * @return True if the functions never returns false or nil.
      */
-    default boolean any(Predicate<T> prd) {
-        // ...
-    }
-
-    /**
-     * Passes at least one element of the collection to the each given blocks.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param first The predicate to match at least one element.
-     * @param other The array of predicates to match at least one element.
-     * @return The true if the blocks never return false or nil.
-     */
-    default boolean any(Predicate<X> first, Predicate<X>... other) {
-        // ...
-    }
-
-    /**
-     * Doesn't passes elements of the collection to the given block.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param prd The predicate to match none elements.
-     * @return The true if the block never returns false or nil.
-     */
-    default boolean none(Predicate<T> prd) {
-        // ...
-    }
-
-    /**
-     * Doesn't passes elements of the collection to the each given blocks.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param first The predicate to match none elements.
-     * @param other The array of predicates to match none elements.
-     * @return The true if the blocks never returns false or nil.
-     */
-    default boolean none(Predicate<X> first, Predicate<X>... other) {
-        // ...
-    }
-    
-    /**
-     * Returns an enumerable containing all elements of enumerable for which the given function
-     *  returns a true value.
-     * If no predicate (null) is given, then 'this' is returned instead.
-     * @param prd The function to match each element.
-     * @return The enumerable.
-     */
-    default Enumerable<T> select(Predicate<T> prd) {
+    default boolean none(Predicate<T>... prd) {
         // ...
     }
 
@@ -137,11 +94,10 @@ public interface Enumerable<X> extends Collection<X> {
      * Returns an enumerable containing all elements of enumerable for which the given functions
      *  return a true value.
      * If no predicate (null) is given, then 'this' is returned instead.
-     * @param first The function to match each element.
-     * @param other The array of predicates to match each element.
+     * @param prd The array of functions to match each element.
      * @return The enumerable.
      */
-    default Enumerable<X> select(Predicate<X> first, Predicate<X>... other) {
+    default Enumerable<T> select(Predicate<T>... prd) {
         // ...
     }
 

--- a/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
+++ b/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
@@ -55,12 +55,9 @@ public interface Enumerable<X> extends Collection<X> {
     default boolean all(Predicate<X>... prd) {
         boolean match = true;
         if (prd != null) {
-            for (final Predicate<X> fnc : prd) {
-                if (!match) {
-                    break;
-                }
-                if (fnc != null) {
-                    match = this.stream().allMatch(fnc);
+            for (int idx = 0; match && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
+                    match = this.stream().allMatch(prd[idx]);
                 }
             }
         }
@@ -86,12 +83,9 @@ public interface Enumerable<X> extends Collection<X> {
     default boolean none(Predicate<X>... prd) {
         boolean match = true;
         if (prd != null) {
-            for (final Predicate<X> fnc : prd) {
-                if (!match) {
-                    break;
-                }
-                if (fnc != null) {
-                    match = this.stream().noneMatch(fnc);
+            for (int idx = 0; match && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
+                    match = this.stream().noneMatch(prd[idx]);
                 }
             }
         }
@@ -108,13 +102,10 @@ public interface Enumerable<X> extends Collection<X> {
     default Enumerable<X> select(Predicate<X>... prd) {
         Enumerable<X> out = this;
         if (prd != null) {
-            for (final Predicate<X> fnc : prd) {
-                if (out.isEmpty()) {
-                    break;
-                }
-                if (fnc != null) {
+            for (int idx = 0; !out.isEmpty() && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
                     out = new Linked<>(
-                        out.stream().filter(fnc).collect(Collectors.toList())
+                        out.stream().filter(prd[idx]).collect(Collectors.toList())
                     );
                 }
             }

--- a/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
+++ b/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
@@ -62,6 +62,20 @@ public interface Enumerable<X> extends Collection<X> {
     }
 
     /**
+     * Passes each element of the collection to the each given blocks.
+     * @param first The predicate to match each element.
+     * @param other The array of predicates to match each element.
+     * @return The true if the blocks never return false or nil.
+     */
+    default boolean all(Predicate<X> first, Predicate<X>... other) {
+        boolean match = this.all(first);
+        for (int idx = 0; match && idx < other.length; ++idx) {
+            match = this.all(other[idx]);
+        }
+        return match;
+    }
+
+    /**
      * Passes at least one element of the collection to the given block.
      * If no predicate (null) is given, then true is returned instead.
      * @param prd The predicate to match at least one element.
@@ -75,6 +89,17 @@ public interface Enumerable<X> extends Collection<X> {
             match = this.stream().anyMatch(prd);
         }
         return match;
+    }
+
+    /**
+     * Passes at least one element of the collection to the each given blocks.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param first The predicate to match at least one element.
+     * @param other The array of predicates to match at least one element.
+     * @return The true if the blocks never return false or nil.
+     */
+    default boolean any(Predicate<X> first, Predicate<X>... other) {
+        return !this.select(first, other).isEmpty();
     }
 
     /**
@@ -94,6 +119,21 @@ public interface Enumerable<X> extends Collection<X> {
     }
 
     /**
+     * Doesn't passes elements of the collection to the each given blocks.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param first The predicate to match none elements.
+     * @param other The array of predicates to match none elements.
+     * @return The true if the blocks never returns false or nil.
+     */
+    default boolean none(Predicate<X> first, Predicate<X>... other) {
+        boolean match = this.none(first);
+        for (int idx = 0; match && idx < other.length; ++idx) {
+            match = this.none(other[idx]);
+        }
+        return match;
+    }
+
+    /**
      * Returns an enumerable containing all elements of enumerable for which the given function
      *  returns a true value.
      * If no predicate (null) is given, then 'this' is returned instead.
@@ -108,6 +148,22 @@ public interface Enumerable<X> extends Collection<X> {
             out = new Linked<>(
                 this.stream().filter(prd).collect(Collectors.toList())
             );
+        }
+        return out;
+    }
+
+    /**
+     * Returns an enumerable containing all elements of enumerable for which the given functions
+     *  return a true value.
+     * If no predicate (null) is given, then 'this' is returned instead.
+     * @param first The function to match each element.
+     * @param other The array of predicates to match each element.
+     * @return The enumerable.
+     */
+    default Enumerable<X> select(Predicate<X> first, Predicate<X>... other) {
+        Enumerable<X> out = this.select(first);
+        for (int idx = 0; !out.isEmpty() && idx < other.length; ++idx) {
+            out = out.select(other[idx]);
         }
         return out;
     }

--- a/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
+++ b/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
@@ -55,9 +55,12 @@ public interface Enumerable<X> extends Collection<X> {
     default boolean all(Predicate<X>... prd) {
         boolean match = true;
         if (prd != null) {
-            for (int idx = 0; match && idx < prd.length; ++idx) {
-                if (prd[idx] != null) {
-                    match = this.stream().allMatch(prd[idx]);
+            for (final Predicate<X> fnc : prd) {
+                if (!match) {
+                    break;
+                }
+                if (fnc != null) {
+                    match = this.stream().allMatch(fnc);
                 }
             }
         }
@@ -83,9 +86,12 @@ public interface Enumerable<X> extends Collection<X> {
     default boolean none(Predicate<X>... prd) {
         boolean match = true;
         if (prd != null) {
-            for (int idx = 0; match && idx < prd.length; ++idx) {
-                if (prd[idx] != null) {
-                    match = this.stream().noneMatch(prd[idx]);
+            for (final Predicate<X> fnc : prd) {
+                if (!match) {
+                    break;
+                }
+                if (fnc != null) {
+                    match = this.stream().noneMatch(fnc);
                 }
             }
         }
@@ -102,10 +108,13 @@ public interface Enumerable<X> extends Collection<X> {
     default Enumerable<X> select(Predicate<X>... prd) {
         Enumerable<X> out = this;
         if (prd != null) {
-            for (int idx = 0; !out.isEmpty() && idx < prd.length; ++idx) {
-                if (prd[idx] != null) {
+            for (final Predicate<X> fnc : prd) {
+                if (out.isEmpty()) {
+                    break;
+                }
+                if (fnc != null) {
                     out = new Linked<>(
-                        out.stream().filter(prd[idx]).collect(Collectors.toList())
+                        out.stream().filter(fnc).collect(Collectors.toList())
                     );
                 }
             }

--- a/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
+++ b/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
@@ -47,124 +47,68 @@ import java.util.stream.Collectors;
 public interface Enumerable<X> extends Collection<X> {
 
     /**
-     * Passes each element of the collection to the given block.
+     * Passes each element of the collection to the each given function.
      * If no predicate (null) is given, then true is returned instead.
-     * @param prd The predicate to match each element.
-     * @return The true if the block never returns false or nil.
+     * @param prd The array of functions to match each element.
+     * @return True if the functions never return false or nil.
      */
-    default boolean all(Predicate<X> prd) {
-        final boolean match;
-        if (prd == null) {
-            match = true;
-        } else {
-            match = this.stream().allMatch(prd);
+    default boolean all(Predicate<X>... prd) {
+        boolean match = true;
+        if (prd != null) {
+            for (int idx = 0; match && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
+                    match = this.stream().allMatch(prd[idx]);
+                }
+            }
         }
         return match;
     }
 
     /**
-     * Passes each element of the collection to the each given blocks.
-     * @param first The predicate to match each element.
-     * @param other The array of predicates to match each element.
-     * @return The true if the blocks never return false or nil.
+     * Passes at least one element of the collection to the each given function.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param prd The array of functions to match at least one element.
+     * @return True if the functions never return false or nil.
      */
-    default boolean all(Predicate<X> first, Predicate<X>... other) {
-        boolean match = this.all(first);
-        for (int idx = 0; match && idx < other.length; ++idx) {
-            match = this.all(other[idx]);
+    default boolean any(Predicate<X>... prd) {
+        return !this.select(prd).isEmpty();
+    }
+
+    /**
+     * Doesn't passes elements of the collection to the each given function.
+     * If no predicate (null) is given, then true is returned instead.
+     * @param prd The array of functions to match none elements.
+     * @return True if the functions never returns false or nil.
+     */
+    default boolean none(Predicate<X>... prd) {
+        boolean match = true;
+        if (prd != null) {
+            for (int idx = 0; match && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
+                    match = this.stream().noneMatch(prd[idx]);
+                }
+            }
         }
         return match;
-    }
-
-    /**
-     * Passes at least one element of the collection to the given block.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param prd The predicate to match at least one element.
-     * @return The true if the block never returns false or nil.
-     */
-    default boolean any(Predicate<X> prd) {
-        final boolean match;
-        if (prd == null) {
-            match = true;
-        } else {
-            match = this.stream().anyMatch(prd);
-        }
-        return match;
-    }
-
-    /**
-     * Passes at least one element of the collection to the each given blocks.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param first The predicate to match at least one element.
-     * @param other The array of predicates to match at least one element.
-     * @return The true if the blocks never return false or nil.
-     */
-    default boolean any(Predicate<X> first, Predicate<X>... other) {
-        return !this.select(first, other).isEmpty();
-    }
-
-    /**
-     * Doesn't passes elements of the collection to the given block.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param prd The predicate to match none elements.
-     * @return The true if the block never returns false or nil.
-     */
-    default boolean none(Predicate<X> prd) {
-        final boolean match;
-        if (prd == null) {
-            match = true;
-        } else {
-            match = this.stream().noneMatch(prd);
-        }
-        return match;
-    }
-
-    /**
-     * Doesn't passes elements of the collection to the each given blocks.
-     * If no predicate (null) is given, then true is returned instead.
-     * @param first The predicate to match none elements.
-     * @param other The array of predicates to match none elements.
-     * @return The true if the blocks never returns false or nil.
-     */
-    default boolean none(Predicate<X> first, Predicate<X>... other) {
-        boolean match = this.none(first);
-        for (int idx = 0; match && idx < other.length; ++idx) {
-            match = this.none(other[idx]);
-        }
-        return match;
-    }
-
-    /**
-     * Returns an enumerable containing all elements of enumerable for which the given function
-     *  returns a true value.
-     * If no predicate (null) is given, then 'this' is returned instead.
-     * @param prd The function to match each element.
-     * @return The enumerable.
-     */
-    default Enumerable<X> select(Predicate<X> prd) {
-        final Enumerable<X> out;
-        if (prd == null) {
-            out = this;
-        } else {
-            out = new Linked<>(
-                this.stream().filter(prd).collect(Collectors.toList())
-            );
-        }
-        return out;
     }
 
     /**
      * Returns an enumerable containing all elements of enumerable for which the given functions
      *  return a true value.
      * If no predicate (null) is given, then 'this' is returned instead.
-     * @param first The function to match each element.
-     * @param other The array of predicates to match each element.
+     * @param prd The array of functions to match each element.
      * @return The enumerable.
      */
-    default Enumerable<X> select(Predicate<X> first, Predicate<X>... other) {
-        Enumerable<X> out = this.select(first);
-        for (int idx = 0; !out.isEmpty() && idx < other.length; ++idx) {
-            out = out.select(other[idx]);
+    default Enumerable<X> select(Predicate<X>... prd) {
+        Enumerable<X> out = this;
+        if (prd != null) {
+            for (int idx = 0; !out.isEmpty() && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
+                    out = new Linked<>(
+                        out.stream().filter(prd[idx]).collect(Collectors.toList())
+                    );
+                }
+            }
         }
         return out;
     }

--- a/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
+++ b/src/main/java/io/github/dgroup/enumerable4j/Enumerable.java
@@ -71,7 +71,21 @@ public interface Enumerable<X> extends Collection<X> {
      * @return True if the functions never return false or nil.
      */
     default boolean any(Predicate<X>... prd) {
-        return !this.select(prd).isEmpty();
+        final boolean match;
+        if (prd == null) {
+            match = true;
+        } else {
+            Enumerable<X> out = this;
+            for (int idx = 0; !out.isEmpty() && idx < prd.length; ++idx) {
+                if (prd[idx] != null) {
+                    out = new Linked<>(
+                        out.stream().filter(prd[idx]).collect(Collectors.toList())
+                    );
+                }
+            }
+            match = !out.isEmpty();
+        }
+        return match;
     }
 
     /**
@@ -96,18 +110,24 @@ public interface Enumerable<X> extends Collection<X> {
      * Returns an enumerable containing all elements of enumerable for which the given functions
      *  return a true value.
      * If no predicate (null) is given, then 'this' is returned instead.
-     * @param prd The array of functions to match each element.
+     * @param first The function to match each element.
+     * @param other The array of functions to match each element.
      * @return The enumerable.
      */
-    default Enumerable<X> select(Predicate<X>... prd) {
-        Enumerable<X> out = this;
-        if (prd != null) {
-            for (int idx = 0; !out.isEmpty() && idx < prd.length; ++idx) {
-                if (prd[idx] != null) {
-                    out = new Linked<>(
-                        out.stream().filter(prd[idx]).collect(Collectors.toList())
-                    );
-                }
+    default Enumerable<X> select(Predicate<X> first, Predicate<X>... other) {
+        Enumerable<X> out;
+        if (first == null) {
+            out = this;
+        } else {
+            out = new Linked<>(
+                this.stream().filter(first).collect(Collectors.toList())
+            );
+        }
+        for (int idx = 0; !out.isEmpty() && idx < other.length; ++idx) {
+            if (other[idx] != null) {
+                out = new Linked<>(
+                    out.stream().filter(other[idx]).collect(Collectors.toList())
+                );
             }
         }
         return out;

--- a/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
@@ -24,6 +24,7 @@
 
 package io.github.dgroup.enumerable4j;
 
+import java.util.function.Predicate;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -62,6 +63,27 @@ final class AllTest {
         new Assertion<>(
             "In case of null predicate we will get true",
             new Linked<>(1, 2, 3).all(null),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsAll() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        final Predicate<Integer> lessthan = val -> val < 7;
+        new Assertion<>(
+            "All values in enumerable are positive, even and less than 7",
+            new Linked<>(2, 4, 6).all(positive, even, lessthan),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNullPredicate() {
+        new Assertion<>(
+            "In case of null predicate we will get true",
+            new Linked<>(1, 2, 3).all(null, null, null),
             new IsTrue()
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
@@ -87,4 +87,13 @@ final class AllTest {
             new IsTrue()
         ).affirm();
     }
+
+    @Test
+    void noArgs() {
+        new Assertion<>(
+            "In case of no-args invocation we will get true",
+            new Linked<>(1, 2, 3).all(),
+            new IsTrue()
+        ).affirm();
+    }
 }

--- a/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
@@ -80,7 +80,7 @@ final class AllTest {
     }
 
     @Test
-    void varArgsNullPredicate() {
+    void varArgsNullPredicates() {
         new Assertion<>(
             "In case of null predicate we will get true",
             new Linked<>(1, 2, 3).all(null, null, null),

--- a/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AllTest.java
@@ -52,7 +52,7 @@ final class AllTest {
     @Test
     void negative() {
         new Assertion<>(
-            "All values in enumerable are negative",
+            "Not all values in enumerable are negative",
             new Linked<>(1, 2, 3).all(val -> val < 0),
             new IsEqual<>(false)
         ).affirm();
@@ -61,7 +61,7 @@ final class AllTest {
     @Test
     void nullPredicate() {
         new Assertion<>(
-            "In case of null predicate we will get true",
+            "In case of null predicate we get true",
             new Linked<>(1, 2, 3).all(null),
             new IsTrue()
         ).affirm();
@@ -80,19 +80,21 @@ final class AllTest {
     }
 
     @Test
-    void varArgsNullPredicates() {
+    void varArgsNegative() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> negative = val -> val < 0;
         new Assertion<>(
-            "In case of null predicate we will get true",
-            new Linked<>(1, 2, 3).all(null, null, null),
-            new IsTrue()
+            "There are positive values in the enumerable, but there are no negative",
+            new Linked<>(1, 2, 3).all(positive, negative),
+            new IsEqual<>(false)
         ).affirm();
     }
 
     @Test
-    void noArgs() {
+    void varArgsNullPredicates() {
         new Assertion<>(
-            "In case of no-args invocation we will get true",
-            new Linked<>(1, 2, 3).all(),
+            "In case of null predicate we will get true",
+            new Linked<>(1, 2, 3).all(null, null, null),
             new IsTrue()
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
@@ -86,13 +86,4 @@ final class AnyTest {
             new IsTrue()
         ).affirm();
     }
-
-    @Test
-    void noArgs() {
-        new Assertion<>(
-            "In case of no-args invocation we will get true",
-            new Linked<>(1, 2, 3).any(),
-            new IsTrue()
-        ).affirm();
-    }
 }

--- a/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
@@ -24,6 +24,7 @@
 
 package io.github.dgroup.enumerable4j;
 
+import java.util.function.Predicate;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -61,6 +62,27 @@ final class AnyTest {
         new Assertion<>(
             "In case of null predicate we will get true",
             new Linked<>(1, 2, 3).any(null),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsAny() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        final Predicate<Integer> lessthan = val -> val < 3;
+        new Assertion<>(
+            "At least one element in enumerable is positive, even and less than 3",
+            new Linked<>(0, 1, 2, 3, 4).any(positive, even, lessthan),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNullPredicate() {
+        new Assertion<>(
+            "In case of null predicate we will get true",
+            new Linked<>(1, 2, 3).any(null, null, null),
             new IsTrue()
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
@@ -79,7 +79,7 @@ final class AnyTest {
     }
 
     @Test
-    void varArgsNullPredicate() {
+    void varArgsNullPredicates() {
         new Assertion<>(
             "In case of null predicate we will get true",
             new Linked<>(1, 2, 3).any(null, null, null),

--- a/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/AnyTest.java
@@ -86,4 +86,13 @@ final class AnyTest {
             new IsTrue()
         ).affirm();
     }
+
+    @Test
+    void noArgs() {
+        new Assertion<>(
+            "In case of no-args invocation we will get true",
+            new Linked<>(1, 2, 3).any(),
+            new IsTrue()
+        ).affirm();
+    }
 }

--- a/src/test/java/io/github/dgroup/enumerable4j/CountTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/CountTest.java
@@ -24,6 +24,7 @@
 
 package io.github.dgroup.enumerable4j;
 
+import java.util.function.Predicate;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -38,7 +39,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class CountTest {
     @Test
-    void truePredicate() {
+    void count() {
         new Assertion<>(
             "One element in enumerable is less than 0",
             new Linked<>(-1, 0, 1, 2).count(val -> val < 0),
@@ -47,7 +48,7 @@ final class CountTest {
     }
 
     @Test
-    void falsePredicate() {
+    void negative() {
         new Assertion<>(
             "No element in enumerable is less than 0",
             new Linked<>(7, 0, 1, 2).count(val -> val < 0),
@@ -60,6 +61,37 @@ final class CountTest {
         new Assertion<>(
             "In case of null predicate it will work as size",
             new Linked<>(1, 2, 3).count(null),
+            new IsEqual<>(3L)
+        ).affirm();
+    }
+
+    @Test
+    void varArgsCount() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> odd = val -> (val & 1) == 1;
+        new Assertion<>(
+            "Two elements in enumerable are greater than 0 and odd",
+            new Linked<>(-1, 0, 1, 2, 3).count(positive, odd),
+            new IsEqual<>(2L)
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNegative() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> odd = val -> (val & 1) == 1;
+        new Assertion<>(
+            "No element in enumerable are greater than 0 and odd",
+            new Linked<>(0, 2, 4).count(positive, odd),
+            new IsEqual<>(0L)
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNullPredicate() {
+        new Assertion<>(
+            "In case of null predicate it will work as size",
+            new Linked<>(1, 2, 3).count(null, null, null),
             new IsEqual<>(3L)
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
@@ -78,7 +78,7 @@ final class NoneTest {
     }
 
     @Test
-    void varArgsNullPredicate() {
+    void varArgsNullPredicates() {
         new Assertion<>(
             "In case of null predicate we will get true",
             new Linked<>(1, 2, 3).none(null, null, null),

--- a/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
@@ -51,7 +51,7 @@ final class NoneTest {
     @Test
     void negative() {
         new Assertion<>(
-            "There are no positive values in the enumerable",
+            "There are some positive values in the enumerable",
             new Linked<>(1, 2, 3).none(val -> val > 0),
             new IsEqual<>(false)
         ).affirm();
@@ -79,19 +79,21 @@ final class NoneTest {
     }
 
     @Test
-    void varArgsNullPredicates() {
+    void varArgsNegative() {
+        final Predicate<Integer> negative = val -> val < 0;
+        final Predicate<Integer> positive = val -> val > 0;
         new Assertion<>(
-            "In case of null predicate we will get true",
-            new Linked<>(1, 2, 3).none(null, null, null),
-            new IsTrue()
+            "There are no negative values in the enumerable, but there are positive",
+            new Linked<>(1, 2, 3).all(negative, positive),
+            new IsEqual<>(false)
         ).affirm();
     }
 
     @Test
-    void noArgs() {
+    void varArgsNullPredicates() {
         new Assertion<>(
-            "In case of no-args invocation we will get true",
-            new Linked<>(1, 2, 3).none(),
+            "In case of null predicate we will get true",
+            new Linked<>(1, 2, 3).none(null, null, null),
             new IsTrue()
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
@@ -85,4 +85,13 @@ final class NoneTest {
             new IsTrue()
         ).affirm();
     }
+
+    @Test
+    void noArgs() {
+        new Assertion<>(
+            "In case of no-args invocation we will get true",
+            new Linked<>(1, 2, 3).none(),
+            new IsTrue()
+        ).affirm();
+    }
 }

--- a/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
@@ -24,6 +24,7 @@
 
 package io.github.dgroup.enumerable4j;
 
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
@@ -60,6 +61,27 @@ final class NoneTest {
         new Assertion<>(
             "In case of null predicate we will get true",
             new Linked<>(1, 2, 3).none(null),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNone() {
+        final Predicate<Integer> negative = val -> val < 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        final Predicate<Integer> lessthan = val -> val > 6;
+        new Assertion<>(
+            "There are no values in enumerable which are negative, even or greater than 6",
+            new Linked<>(1, 3, 5).none(negative, even, lessthan),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNullPredicate() {
+        new Assertion<>(
+            "In case of null predicate we will get true",
+            new Linked<>(1, 2, 3).none(null, null, null),
             new IsTrue()
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/NoneTest.java
@@ -25,6 +25,7 @@
 package io.github.dgroup.enumerable4j;
 
 import java.util.function.Predicate;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
@@ -50,9 +51,9 @@ final class NoneTest {
     @Test
     void negative() {
         new Assertion<>(
-            "All values in enumerable are negative",
-            new Linked<>(1, 2, 3).none(val -> val < 0),
-            new IsTrue()
+            "There are no positive values in the enumerable",
+            new Linked<>(1, 2, 3).none(val -> val > 0),
+            new IsEqual<>(false)
         ).affirm();
     }
 

--- a/src/test/java/io/github/dgroup/enumerable4j/RejectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/RejectTest.java
@@ -24,6 +24,8 @@
 
 package io.github.dgroup.enumerable4j;
 
+import java.util.function.Predicate;
+import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -53,10 +55,53 @@ final class RejectTest {
     }
 
     @Test
+    void negate() {
+        new Assertion<>(
+            "All values from enumerable found",
+            new Linked<>(1, 2, 3).reject(val -> val > 0),
+            new IsEmptyIterable<>()
+        ).affirm();
+    }
+
+    @Test
     void nullFunction() {
         new Assertion<>(
             "In case null-function the self enumerable is expected",
             new Linked<>(3, 0, 2, -1).reject(null),
+            new HasValues<>(3, 0, 2, -1)
+        ).affirm();
+    }
+
+    @Test
+    void varArgsReject() {
+        final Predicate<Integer> negative = val -> val < 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        new Assertion<>(
+            "Negative values from enumerable found",
+            new Linked<>(1, 2, 3, -1).reject(negative, even),
+            new AllOf<>(
+                new HasSize(2),
+                new HasValues<>(1, 3)
+            )
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNegate() {
+        final Predicate<Integer> negative = val -> val < 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        new Assertion<>(
+            "No values from enumerable found",
+            new Linked<>(2, 4, 6).reject(negative, even),
+            new IsEmptyIterable<>()
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNullFunction() {
+        new Assertion<>(
+            "In case null-function the self enumerable is expected",
+            new Linked<>(3, 0, 2, -1).reject(null, null, null),
             new HasValues<>(3, 0, 2, -1)
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
@@ -78,7 +78,7 @@ final class SelectTest {
     }
 
     @Test
-    void varArgsNullFunction() {
+    void varArgsNullPredicates() {
         new Assertion<>(
             "In case null-function the self enumerable is expected",
             new Linked<>(3, 0, 2, -1).select(null, null, null),

--- a/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
@@ -95,13 +95,4 @@ final class SelectTest {
             new HasValues<>(3, 0, 2, -1)
         ).affirm();
     }
-
-    @Test
-    void noArgs() {
-        new Assertion<>(
-            "In case of no-args invocation the self enumerable is expected",
-            new Linked<>(1, 2, 3).select(),
-            new HasValues<>(1, 2, 3)
-        ).affirm();
-    }
 }

--- a/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
@@ -24,6 +24,7 @@
 
 package io.github.dgroup.enumerable4j;
 
+import java.util.function.Predicate;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -57,6 +58,30 @@ final class SelectTest {
         new Assertion<>(
             "In case null-function the self enumerable is expected",
             new Linked<>(3, 0, 2, -1).select(null),
+            new HasValues<>(3, 0, 2, -1)
+        ).affirm();
+    }
+
+    @Test
+    void varArgsSelect() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        final Predicate<Integer> lessthan = val -> val < 5;
+        new Assertion<>(
+            "All values in enumerable are positive, even and less than 5",
+            new Linked<>(-1, 0, 1, 2, 3, 4, 5, 6).select(positive, even, lessthan),
+            new AllOf<>(
+                new HasSize(2),
+                new HasValues<>(2, 4)
+            )
+        ).affirm();
+    }
+
+    @Test
+    void varArgsNullFunction() {
+        new Assertion<>(
+            "In case null-function the self enumerable is expected",
+            new Linked<>(3, 0, 2, -1).select(null, null, null),
             new HasValues<>(3, 0, 2, -1)
         ).affirm();
     }

--- a/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
@@ -85,4 +85,13 @@ final class SelectTest {
             new HasValues<>(3, 0, 2, -1)
         ).affirm();
     }
+
+    @Test
+    void noArgs() {
+        new Assertion<>(
+            "In case of no-args invocation the self enumerable is expected",
+            new Linked<>(1, 2, 3).select(),
+            new HasValues<>(1, 2, 3)
+        ).affirm();
+    }
 }

--- a/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
@@ -88,6 +88,18 @@ final class SelectTest {
     }
 
     @Test
+    void varArgsNegative() {
+        final Predicate<Integer> positive = val -> val > 0;
+        final Predicate<Integer> negative = val -> val < 0;
+        final Predicate<Integer> even = val -> (val & 1) == 0;
+        new Assertion<>(
+            "There are positive and even values in the enumerable, but there are no negative",
+            new Linked<>(1, 2, 3).select(positive, negative, even),
+            new IsEmptyIterable<>()
+        ).affirm();
+    }
+
+    @Test
     void varArgsNullPredicates() {
         new Assertion<>(
             "In case null-function the self enumerable is expected",

--- a/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
+++ b/src/test/java/io/github/dgroup/enumerable4j/SelectTest.java
@@ -25,6 +25,7 @@
 package io.github.dgroup.enumerable4j;
 
 import java.util.function.Predicate;
+import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -50,6 +51,15 @@ final class SelectTest {
                 new HasSize(2),
                 new HasValues<>(3, 2)
             )
+        ).affirm();
+    }
+
+    @Test
+    void negative() {
+        new Assertion<>(
+            "There are no negative values in the enumerable",
+            new Linked<>(1, 2, 3).select(val -> val < 0),
+            new IsEmptyIterable<>()
         ).affirm();
     }
 


### PR DESCRIPTION
Add varargs support for '.all', '.any', '.none', '.select' methods

-----
[View rendered readme.md](https://github.com/dykov/enumerable4j/blob/vararg-support/readme.md)